### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/ida-ws/pom.xml
+++ b/ida-ws/pom.xml
@@ -25,12 +25,12 @@
 		<repository>
 			<id>maven.aksw.internal</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/repository/internal</url>
+			<url>https://maven.aksw.org/repository/internal</url>
 		</repository>
 		<repository>
 			<id>maven.aksw.snapshots</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/repository/snapshots</url>
+			<url>https://maven.aksw.org/repository/snapshots</url>
 		</repository>
 	</repositories>
 	<dependencyManagement>


### PR DESCRIPTION
Resolve dependencies of the AKSW repository over https.